### PR TITLE
Replace `pre` elements with `code` elements

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,5 +1,5 @@
-pre {
-  display: inline;
+.pre {
+  white-space: pre;
 }
 
 img {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <h1>
     京都大学
-    <code>&lt;br /&gt;</code> 同好会
+    <code class="pre">&lt;br /&gt;</code> 同好会
   </h1>
 
   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>
@@ -20,17 +20,17 @@
 
   <h2>
     京都大学
-    <code>&lt;br /&gt;</code> 同好会とは
+    <code class="pre">&lt;br /&gt;</code> 同好会とは
   </h2>
   <img src="./logo.png" />
   <br /> 京都大学
-  <code>&lt;br /&gt;</code> 同好会は
-  <code>&lt;br /&gt;</code> が好きな人間が集まる同好会です。
+  <code class="pre">&lt;br /&gt;</code> 同好会は
+  <code class="pre">&lt;br /&gt;</code> が好きな人間が集まる同好会です。
   <br />
   <h2>
-    <code>&lt;br /&gt;</code> とは?
+    <code class="pre">&lt;br /&gt;</code> とは?
   </h2>
-  <code>&lt;br /&gt;</code> は、HTML5 / XHTML1.1 で改行を意味するタグです。
+  <code class="pre">&lt;br /&gt;</code> は、HTML5 / XHTML1.1 で改行を意味するタグです。
   <br />
 
   <h3>
@@ -40,14 +40,14 @@
 
   <h3>
     京都大学
-    <code>&lt;br /&gt;</code> 同好会の推奨する br タグ
+    <code class="pre">&lt;br /&gt;</code> 同好会の推奨する br タグ
   </h3>
 
   京都大学
-  <code>&lt;br /&gt;</code> 同好会では
-  <code>&lt;br /&gt;</code> の使用を推奨しています。
+  <code class="pre">&lt;br /&gt;</code> 同好会では
+  <code class="pre">&lt;br /&gt;</code> の使用を推奨しています。
   <a href="https://www.w3.org/TR/html5/syntax.html#start-tags">HTML5 でも、
-    <code>&lt;br /&gt;</code> は使用できます</a>。
+    <code class="pre">&lt;br /&gt;</code> は使用できます</a>。
   <br />
 
   <h3>
@@ -55,50 +55,50 @@
   </h3>
 
   <h4>
-    <code>&lt;br&gt;</code>
+    <code class="pre">&lt;br&gt;</code>
   </h4>
 
   <a href="https://www.w3.org/TR/xhtml1/#h-4.6">
-    <code>&lt;br&gt;</code> は XHTML1.1 では許容されません</a>。
-  <code>&lt;br /&gt;</code> を推奨します。
+    <code class="pre">&lt;br&gt;</code> は XHTML1.1 では許容されません</a>。
+  <code class="pre">&lt;br /&gt;</code> を推奨します。
   <br />
 
 
   <h4>
-    <code>&lt;br/&gt;</code>
+    <code class="pre">&lt;br/&gt;</code>
   </h4>
 
   古いブラウザとの互換性のため、
-  <code>&lt;br /&gt;</code> を推奨します。
+  <code class="pre">&lt;br /&gt;</code> を推奨します。
   <a href="https://www.w3.org/TR/xhtml1/#C_2">これは XHTML1.1 でも言及されています</a>。
   <br />
 
   <h4>
-    <code>&lt;br&gt;&lt;/br&gt;</code>
+    <code class="pre">&lt;br&gt;&lt;/br&gt;</code>
   </h4>
 
   XHTML1.1 では有効ですが、
   <a href="https://www.w3.org/TR/html5/syntax.html#void-elements">HTML5 では許容されません</a>。
-  <code>&lt;br /&gt;</code> を推奨します。
+  <code class="pre">&lt;br /&gt;</code> を推奨します。
   <br />
 
   <h4>
-    <code>&lt;br  /&gt;</code>
+    <code class="pre">&lt;br  /&gt;</code>
   </h4>
   不要なスペースは削りましょう。
-  <code>&lt;br /&gt;</code> を推奨します。
+  <code class="pre">&lt;br /&gt;</code> を推奨します。
   <br />
 
   <h2>
     活動
   </h2>
-  <code>&lt;br /&gt;</code> を用いた HTML5 / XHTML1.1 ドキュメントを作成します。
+  <code class="pre">&lt;br /&gt;</code> を用いた HTML5 / XHTML1.1 ドキュメントを作成します。
   <br />
 
   <h2>
     入会
   </h2>
-  <code>&lt;br /&gt;</code> を好む人間であれば、誰でも入会できます。
+  <code class="pre">&lt;br /&gt;</code> を好む人間であれば、誰でも入会できます。
   <br />
 
   <h2>
@@ -107,13 +107,13 @@
   <ul>
     <li>
       <a href="./validator.html">京都大学
-        <code>&lt;br /&gt;</code> 同好会
-        <code>&lt;br /&gt;</code> バリデータ</a>
+        <code class="pre">&lt;br /&gt;</code> 同好会
+        <code class="pre">&lt;br /&gt;</code> バリデータ</a>
     </li>
     <li>
       <a href="./uranai.html">京都大学
-        <code>&lt;br /&gt;</code> 同好会
-        <code>&lt;br /&gt;</code> 占い</a>
+        <code class="pre">&lt;br /&gt;</code> 同好会
+        <code class="pre">&lt;br /&gt;</code> 占い</a>
     </li>
 
   </ul>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <h1>
     京都大学
-    <pre>&lt;br /&gt;</pre> 同好会
+    <code>&lt;br /&gt;</code> 同好会
   </h1>
 
   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>
@@ -20,17 +20,17 @@
 
   <h2>
     京都大学
-    <pre>&lt;br /&gt;</pre> 同好会とは
+    <code>&lt;br /&gt;</code> 同好会とは
   </h2>
   <img src="./logo.png" />
   <br /> 京都大学
-  <pre>&lt;br /&gt;</pre> 同好会は
-  <pre>&lt;br /&gt;</pre> が好きな人間が集まる同好会です。
+  <code>&lt;br /&gt;</code> 同好会は
+  <code>&lt;br /&gt;</code> が好きな人間が集まる同好会です。
   <br />
   <h2>
-    <pre>&lt;br /&gt;</pre> とは?
+    <code>&lt;br /&gt;</code> とは?
   </h2>
-  <pre>&lt;br /&gt;</pre> は、HTML5 / XHTML1.1 で改行を意味するタグです。
+  <code>&lt;br /&gt;</code> は、HTML5 / XHTML1.1 で改行を意味するタグです。
   <br />
 
   <h3>
@@ -40,14 +40,14 @@
 
   <h3>
     京都大学
-    <pre>&lt;br /&gt;</pre> 同好会の推奨する br タグ
+    <code>&lt;br /&gt;</code> 同好会の推奨する br タグ
   </h3>
 
   京都大学
-  <pre>&lt;br /&gt;</pre> 同好会では
-  <pre>&lt;br /&gt;</pre> の使用を推奨しています。
+  <code>&lt;br /&gt;</code> 同好会では
+  <code>&lt;br /&gt;</code> の使用を推奨しています。
   <a href="https://www.w3.org/TR/html5/syntax.html#start-tags">HTML5 でも、
-    <pre>&lt;br /&gt;</pre> は使用できます</a>。
+    <code>&lt;br /&gt;</code> は使用できます</a>。
   <br />
 
   <h3>
@@ -55,50 +55,50 @@
   </h3>
 
   <h4>
-    <pre>&lt;br&gt;</pre>
+    <code>&lt;br&gt;</code>
   </h4>
 
   <a href="https://www.w3.org/TR/xhtml1/#h-4.6">
-    <pre>&lt;br&gt;</pre> は XHTML1.1 では許容されません</a>。
-  <pre>&lt;br /&gt;</pre> を推奨します。
+    <code>&lt;br&gt;</code> は XHTML1.1 では許容されません</a>。
+  <code>&lt;br /&gt;</code> を推奨します。
   <br />
 
 
   <h4>
-    <pre>&lt;br/&gt;</pre>
+    <code>&lt;br/&gt;</code>
   </h4>
 
   古いブラウザとの互換性のため、
-  <pre>&lt;br /&gt;</pre> を推奨します。
+  <code>&lt;br /&gt;</code> を推奨します。
   <a href="https://www.w3.org/TR/xhtml1/#C_2">これは XHTML1.1 でも言及されています</a>。
   <br />
 
   <h4>
-    <pre>&lt;br&gt;&lt;/br&gt;</pre>
+    <code>&lt;br&gt;&lt;/br&gt;</code>
   </h4>
 
   XHTML1.1 では有効ですが、
   <a href="https://www.w3.org/TR/html5/syntax.html#void-elements">HTML5 では許容されません</a>。
-  <pre>&lt;br /&gt;</pre> を推奨します。
+  <code>&lt;br /&gt;</code> を推奨します。
   <br />
 
   <h4>
-    <pre>&lt;br  /&gt;</pre>
+    <code>&lt;br  /&gt;</code>
   </h4>
   不要なスペースは削りましょう。
-  <pre>&lt;br /&gt;</pre> を推奨します。
+  <code>&lt;br /&gt;</code> を推奨します。
   <br />
 
   <h2>
     活動
   </h2>
-  <pre>&lt;br /&gt;</pre> を用いた HTML5 / XHTML1.1 ドキュメントを作成します。
+  <code>&lt;br /&gt;</code> を用いた HTML5 / XHTML1.1 ドキュメントを作成します。
   <br />
 
   <h2>
     入会
   </h2>
-  <pre>&lt;br /&gt;</pre> を好む人間であれば、誰でも入会できます。
+  <code>&lt;br /&gt;</code> を好む人間であれば、誰でも入会できます。
   <br />
 
   <h2>
@@ -107,13 +107,13 @@
   <ul>
     <li>
       <a href="./validator.html">京都大学
-        <pre>&lt;br /&gt;</pre> 同好会
-        <pre>&lt;br /&gt;</pre> バリデータ</a>
+        <code>&lt;br /&gt;</code> 同好会
+        <code>&lt;br /&gt;</code> バリデータ</a>
     </li>
     <li>
       <a href="./uranai.html">京都大学
-        <pre>&lt;br /&gt;</pre> 同好会
-        <pre>&lt;br /&gt;</pre> 占い</a>
+        <code>&lt;br /&gt;</code> 同好会
+        <code>&lt;br /&gt;</code> 占い</a>
     </li>
 
   </ul>

--- a/uranai.html
+++ b/uranai.html
@@ -11,8 +11,8 @@
 <body>
   <h1>
     京都大学
-    <pre>&lt;br /&gt;</pre> 同好会
-    <pre>&lt;br /&gt;</pre> 占い
+    <code>&lt;br /&gt;</code> 同好会
+    <code>&lt;br /&gt;</code> 占い
   </h1>
 
   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>

--- a/uranai.html
+++ b/uranai.html
@@ -11,8 +11,8 @@
 <body>
   <h1>
     京都大学
-    <code>&lt;br /&gt;</code> 同好会
-    <code>&lt;br /&gt;</code> 占い
+    <code class="pre">&lt;br /&gt;</code> 同好会
+    <code class="pre">&lt;br /&gt;</code> 占い
   </h1>
 
   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>

--- a/validator.html
+++ b/validator.html
@@ -11,8 +11,8 @@
 <body>
   <h1>
     京都大学
-    <code>&lt;br /&gt;</code> 同好会
-    <code>&lt;br /&gt;</code> バリデータ
+    <code class="pre">&lt;br /&gt;</code> 同好会
+    <code class="pre">&lt;br /&gt;</code> バリデータ
   </h1>
 
   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>

--- a/validator.html
+++ b/validator.html
@@ -11,8 +11,8 @@
 <body>
   <h1>
     京都大学
-    <pre>&lt;br /&gt;</pre> 同好会
-    <pre>&lt;br /&gt;</pre> バリデータ
+    <code>&lt;br /&gt;</code> 同好会
+    <code>&lt;br /&gt;</code> バリデータ
   </h1>
 
   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a>


### PR DESCRIPTION
The `pre` element represents a block of preformatted text. ( See : https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element )
In those cases, `code` elements are appropriate.

In addition, the HTMLs are not valid if `pre` elements are used: https://html5.validator.nu/?doc=https%3A%2F%2Fku-brclose.github.io%2F

> Error: Element pre not allowed as child of element h1 in this context. (Suppressing further errors from this subtree.)
> 
> From line 14, column 5; to line 14, column 9
>
> 京都大学↩    &lt;pre>&amp;lt;br
>
> Contexts in which element pre may be used:
>    Where flow content is expected.
