### PR TITLE
Fix stray `script` start tags

### DIFF
--- a/uranai.html
+++ b/uranai.html
@@ -52,8 +52,8 @@
   <br />
   <br />
   <br />
-</body>
 
-<script type="text/javascript" src="./uranai.js"></script>
+  <script type="text/javascript" src="./uranai.js"></script>
+</body>
 
 </html>

--- a/validator.html
+++ b/validator.html
@@ -27,8 +27,8 @@
   <br />
   <br />
   <br />
-</body>
 
-<script type="text/javascript" src="./validator.js"></script>
+  <script type="text/javascript" src="./validator.js"></script>
+</body>
 
 </html>


### PR DESCRIPTION
It's invalid if `script` tag is placed after `body` close tag.

See : https://html5.validator.nu/?doc=https%3A%2F%2Fku-brclose.github.io%2Furanai.html

> Error: Stray start tag script.
>
> From line 57, column 1; to line 57, column 49
>
> ↩&lt;/body>↩↩&lt;script type="text/javascript" src="./uranai.js">&lt;/scri